### PR TITLE
add in dotenv package to pick up values in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ To run the application, you need to have both the backend and the frontend up an
 
 #### 1. Run backend
 
-From the **backend** directory, run:
+From the **backend** directory, first copy `.env.example` to `.env` and change the value if you want. It doesn't necessarily matter for local development, but the secret value in production should be a random alphanumeric string with symbols. Once that's configured, run:
 
 ```bash
 python manage.py runserver

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+# copy this file over to .env and change the value if you're using it in production
+DJANGO_SECRET_KEY=badkeypleasechangeforproduction

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 import os
+from dotenv import load_dotenv, find_dotenv
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -17,6 +18,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
+
+# Load environment definition file
+ENV_FILE = find_dotenv()
+if ENV_FILE:
+    load_dotenv(ENV_FILE)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,6 +21,7 @@ packaging==23.2
 Pillow==10.1.0
 pycparser==2.21
 PyJWT==2.8.0
+python-dotenv~=0.19
 python3-openid==3.2.0
 pytz==2023.3.post1
 requests==2.31.0


### PR DESCRIPTION
There's currently a .env file, but no way to pick it up automatically. This commit adds python-dotenv to pick up the values set there automatically.