### PR TITLE
add a meta description for a11y/seo

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Data Dynamo data products">
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@100;200;300;400;500;600;700;800&display=swap">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined">


### PR DESCRIPTION
not having a meta tag for description is a potential a11y and SEO issue, so this commit adds one.